### PR TITLE
refactor(core): rename PymordialController to PymordialBluestacksController

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - `core/element.py` → `core/blueprints/element.py`
     - `ocr/extract_strategies.py` → `devices/extract_strategies.py`
     - `utils/state_machine.py` → `core/state_machine.py`
-- **Controller API**: `PymordialController` now delegates all UI logic to `self.ui` (`PymordialUiDevice`).
+- **Controller API**: `PymordialBluestacksController` now delegates all UI logic to `self.ui` (`PymordialUiDevice`).
 - **Dependencies**: Removed hard dependency on `easyocr`.
 
 ### Removed

--- a/README.md
+++ b/README.md
@@ -83,13 +83,13 @@ app:
 
 ### 1. Connect and Verify
 
-Create a `PymordialController` to manage the connection.
+Create a `PymordialBluestacksController` to manage the connection.
 
 ```python
-from pymordial import PymordialController
+from pymordial import PymordialBluestacksController
 
 # Initialize controller (auto-connects to default ADB host/port)
-controller = PymordialController()
+controller = PymordialBluestacksController()
 
 # Check Device Status
 if controller.bluestacks.is_ready():
@@ -186,7 +186,7 @@ if controller.my_game.is_open():
 The system is organized into a clean implementation hierarchy:
 
 ```
-PymordialController
+PymordialBluestacksController
 ├── adb (PymordialAdbDevice)
 │   ├── AdbShell (Bridge)
 │   ├── Streaming (H.264 -> PyAV)

--- a/examples/01_basic_connection.py
+++ b/examples/01_basic_connection.py
@@ -1,7 +1,7 @@
 """Basic BlueStacks connection example.
 
 This script demonstrates how to:
-1. Create a PymordialController
+1. Create a PymordialBluestacksController
 2. Connect to BlueStacks via ADB
 3. Execute shell commands
 4. Disconnect cleanly
@@ -9,7 +9,7 @@ This script demonstrates how to:
 
 from logging import INFO, basicConfig, getLogger
 
-from pymordial.core.controller import PymordialController
+from pymordial.core.bluestacks_controller import PymordialBluestacksController
 
 logger = getLogger(__name__)
 
@@ -20,8 +20,8 @@ def main():
     logger.info("=== Pymordial Basic Connection Example ===\n")
 
     # Create controller - BlueStacks must be running
-    logger.info("1. Creating PymordialController...")
-    controller = PymordialController()
+    logger.info("1. Creating PymordialBluestacksController...")
+    controller = PymordialBluestacksController()
     logger.info("   ✓ Controller created\n")
 
     # Check if BlueStacks is running

--- a/examples/02_app_control.py
+++ b/examples/02_app_control.py
@@ -11,7 +11,7 @@ import time
 from logging import INFO, basicConfig, getLogger
 
 from pymordial.core.app import PymordialApp
-from pymordial.core.controller import PymordialController
+from pymordial.core.bluestacks_controller import PymordialBluestacksController
 
 logger = getLogger(__name__)
 
@@ -22,8 +22,8 @@ def main():
     logger.info("=== Pymordial App Control Example ===\n")
 
     # Create controller and ensure BlueStacks is running
-    logger.info("1. Creating PymordialController...")
-    controller = PymordialController()
+    logger.info("1. Creating PymordialBluestacksController...")
+    controller = PymordialBluestacksController()
 
     if not controller.bluestacks.is_ready():
         logger.info("   Opening BlueStacks...")

--- a/examples/03_element_clicking.py
+++ b/examples/03_element_clicking.py
@@ -12,7 +12,7 @@ from logging import INFO, basicConfig, getLogger
 from pathlib import Path
 
 from pymordial.core.app import PymordialApp
-from pymordial.core.controller import PymordialController
+from pymordial.core.bluestacks_controller import PymordialBluestacksController
 from pymordial.ui.image import PymordialImage
 from pymordial.ui.pixel import PymordialPixel
 from pymordial.ui.text import PymordialText
@@ -27,8 +27,8 @@ def main():
 
     try:
         # Create controller
-        logger.info("1. Creating PymordialController...")
-        controller = PymordialController()
+        logger.info("1. Creating PymordialBluestacksController...")
+        controller = PymordialBluestacksController()
 
         if not controller.bluestacks.is_ready():
             logger.info("   Opening BlueStacks...")

--- a/examples/04_ocr_reading.py
+++ b/examples/04_ocr_reading.py
@@ -10,7 +10,7 @@ This script demonstrates how to:
 
 from logging import INFO, basicConfig, getLogger
 
-from pymordial.core.controller import PymordialController
+from pymordial.core.bluestacks_controller import PymordialBluestacksController
 from pymordial.devices.extract_strategies import (
     DefaultExtractStrategy,
     RevomonTextStrategy,
@@ -25,8 +25,8 @@ def main():
     logger.info("=== Pymordial OCR Reading Example ===\n")
 
     # Create controller
-    logger.info("1. Creating PymordialController...")
-    controller = PymordialController()
+    logger.info("1. Creating PymordialBluestacksController...")
+    controller = PymordialBluestacksController()
 
     if not controller.bluestacks.is_ready():
         controller.bluestacks.open()

--- a/examples/05_custom_app_screens.py
+++ b/examples/05_custom_app_screens.py
@@ -11,7 +11,7 @@ from logging import INFO, basicConfig, getLogger
 from pathlib import Path
 
 from pymordial.core.app import PymordialApp
-from pymordial.core.controller import PymordialController
+from pymordial.core.bluestacks_controller import PymordialBluestacksController
 from pymordial.core.screen import PymordialScreen
 from pymordial.ui.image import PymordialImage
 from pymordial.ui.text import PymordialText
@@ -25,8 +25,8 @@ def main():
     logger.info("=== Pymordial Custom App Structure Example ===\n")
 
     # Create controller
-    logger.info("1. Creating PymordialController...")
-    controller = PymordialController()
+    logger.info("1. Creating PymordialBluestacksController...")
+    controller = PymordialBluestacksController()
     logger.info("   ✓ Controller created\n")
 
     # Define your custom app

--- a/examples/README.md
+++ b/examples/README.md
@@ -14,7 +14,7 @@ Practical examples demonstrating Pymordial for Android automation on BlueStacks.
 **Basics**: Connecting to BlueStacks via ADB
 
 Learn how to:
-- Create a `PymordialController`
+- Create a `PymordialBluestacksController`
 - Check connection status
 - Execute shell commands
 - Verify Android version

--- a/src/pymordial/__init__.py
+++ b/src/pymordial/__init__.py
@@ -7,7 +7,7 @@ automating BlueStacks interactions.
 from pymordial.core.app import PymordialApp
 from pymordial.core.blueprints.element import PymordialElement
 from pymordial.core.blueprints.emulator_device import EmulatorState
-from pymordial.core.controller import PymordialController
+from pymordial.core.bluestacks_controller import PymordialBluestacksController
 from pymordial.core.screen import PymordialScreen
 from pymordial.core.state_machine import AppState, StateMachine
 from pymordial.devices.adb_device import PymordialAdbDevice
@@ -31,7 +31,7 @@ __all__ = [
     "PymordialApp",
     "PymordialAppError",
     "PymordialConnectionError",
-    "PymordialController",
+    "PymordialBluestacksController",
     "PymordialElement",
     "PymordialEmulatorError",
     "PymordialError",

--- a/src/pymordial/core/__init__.py
+++ b/src/pymordial/core/__init__.py
@@ -10,7 +10,7 @@ from pymordial.core.blueprints.emulator_device import (
     PymordialEmulatorDevice,
 )
 from pymordial.core.blueprints.vision_device import PymordialVisionDevice
-from pymordial.core.controller import PymordialController
+from pymordial.core.bluestacks_controller import PymordialBluestacksController
 from pymordial.core.screen import PymordialScreen
 from pymordial.core.state_machine import AppState, StateMachine
 from pymordial.ui.image import PymordialImage
@@ -29,6 +29,6 @@ __all__ = [
     "PymordialBridgeDevice",
     "AppState",
     "StateMachine",
-    "PymordialController",
+    "PymordialBluestacksController",
     "PymordialVisionDevice",
 ]

--- a/src/pymordial/core/app.py
+++ b/src/pymordial/core/app.py
@@ -9,7 +9,7 @@ from pymordial.utils.config import get_config
 
 if TYPE_CHECKING:
     from pymordial.core.blueprints.element import PymordialElement
-    from pymordial.core.controller import PymordialController
+    from pymordial.core.bluestacks_controller import PymordialBluestacksController
     from pymordial.core.screen import PymordialScreen
 
 
@@ -25,8 +25,8 @@ APP_CLOSE_WAIT_TIME = _CONFIG["app"]["close_wait_time"]
 class PymordialApp:
     """Represents an Android application with lifecycle management.
 
-    The PymordialController reference is automatically set when this app
-    is registered with a controller via PymordialController(apps=[...]) or
+    The PymordialBluestacksController reference is automatically set when this app
+    is registered with a controller via PymordialBluestacksController(apps=[...]) or
     controller.add_app(...).
 
     Attributes:
@@ -67,7 +67,7 @@ class PymordialApp:
 
         self.app_name: str = app_name
         self.package_name: str = package_name
-        self.pymordial_controller: PymordialController | None = None
+        self.pymordial_controller: PymordialBluestacksController | None = None
         self.screens: dict[str, PymordialScreen] = (
             screens if screens is not None else {}
         )

--- a/src/pymordial/core/bluestacks_controller.py
+++ b/src/pymordial/core/bluestacks_controller.py
@@ -27,8 +27,10 @@ logger = logging.getLogger(__name__)
 _CONFIG = get_config()
 
 
-class PymordialController:
+class PymordialBluestacksController:
     """Main controller that orchestrates ADB, BlueStacks, and Image controllers.
+
+    This specific implementation is tailored for BlueStacks automation.
 
     Attributes:
         adb: The PymordialAdbDevice instance.
@@ -47,7 +49,7 @@ class PymordialController:
         adb_port: int | None = None,
         apps: list["PymordialApp"] | None = None,
     ):
-        """Initializes the PymordialController.
+        """Initializes the PymordialBluestacksController.
 
         Args:
             adb_host: Optional ADB host address.
@@ -163,7 +165,7 @@ class PymordialController:
                         "ADB device not connected. Skipping 'click_coords' method call."
                     )
                     return False
-                single_tap = PymordialController.CMD_TAP.format(
+                single_tap = PymordialBluestacksController.CMD_TAP.format(
                     x=coords[0], y=coords[1]
                 )
                 tap_command = " && ".join([single_tap] * times)
@@ -221,7 +223,7 @@ class PymordialController:
                 return False
             case _:
                 logger.warning(
-                    "Cannot click coords - PymordialController.bluestacks_state.current_state is not in a valid state."
+                    "Cannot click coords - PymordialBluestacksController.bluestacks_state.current_state is not in a valid state."
                     " Make sure it is in the 'EmulatorState.READY' state."
                 )
                 return False
@@ -363,7 +365,8 @@ class PymordialController:
                 self.find_element(
                     pymordial_element=pymordial_element,
                     pymordial_screenshot=pymordial_screenshot,
-                    max_tries=max_tries or PymordialController.DEFAULT_MAX_TRIES,
+                    max_tries=max_tries
+                    or PymordialBluestacksController.DEFAULT_MAX_TRIES,
                 )
                 is not None
             )
@@ -402,7 +405,8 @@ class PymordialController:
                 self.find_element(
                     pymordial_element=pymordial_element,
                     pymordial_screenshot=pymordial_screenshot,
-                    max_tries=max_tries or PymordialController.DEFAULT_MAX_TRIES,
+                    max_tries=max_tries
+                    or PymordialBluestacksController.DEFAULT_MAX_TRIES,
                 )
                 is not None
             )
@@ -567,9 +571,9 @@ class PymordialController:
         return self.adb.stop_stream()
 
     def __repr__(self) -> str:
-        """Returns a string representation of the PymordialController."""
+        """Returns a string representation of the PymordialBluestacksController."""
         return (
-            f"PymordialController("
+            f"PymordialBluestacksController("
             f"apps={len(self._apps)}, "
             f"adb_connected={self.adb.is_connected()}, "
             f"bluestacks={self.bluestacks.state.current_state.name})"

--- a/src/pymordial/devices/__init__.py
+++ b/src/pymordial/devices/__init__.py
@@ -2,7 +2,7 @@ from .adb_device import PymordialAdbDevice
 from .bluestacks_device import PymordialBluestacksDevice
 from .ui_device import PymordialUiDevice
 
-# PymordialController moved to core
+# PymordialBluestacksController moved to core
 
 __all__ = [
     "PymordialAdbDevice",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,7 @@ import pytest
 from PIL import Image
 
 from pymordial.core.app import PymordialApp
-from pymordial.core.controller import PymordialController
+from pymordial.core.bluestacks_controller import PymordialBluestacksController
 from pymordial.core.screen import PymordialScreen
 from pymordial.devices.adb_device import PymordialAdbDevice
 from pymordial.devices.bluestacks_device import PymordialBluestacksDevice
@@ -156,7 +156,7 @@ def mock_config():
             create=True,
         ),
         patch(
-            "pymordial.core.controller.get_config",
+            "pymordial.core.bluestacks_controller.get_config",
             return_value=config,
             create=True,
         ),

--- a/tests/core/test_controller.py
+++ b/tests/core/test_controller.py
@@ -3,15 +3,15 @@
 from unittest.mock import patch
 
 from pymordial.core.app import PymordialApp
-from pymordial.core.controller import PymordialController
+from pymordial.core.bluestacks_controller import PymordialBluestacksController
 
 
 def test_pymordial_controller_init():
     """Test PymordialController initialization."""
-    with patch("pymordial.core.controller.PymordialAdbDevice"):
-        with patch("pymordial.core.controller.PymordialBluestacksDevice"):
-            with patch("pymordial.core.controller.PymordialUiDevice"):
-                controller = PymordialController()
+    with patch("pymordial.core.bluestacks_controller.PymordialAdbDevice"):
+        with patch("pymordial.core.bluestacks_controller.PymordialBluestacksDevice"):
+            with patch("pymordial.core.bluestacks_controller.PymordialUiDevice"):
+                controller = PymordialBluestacksController()
                 assert controller.adb is not None
                 assert controller.bluestacks is not None
                 assert controller.ui is not None
@@ -19,10 +19,10 @@ def test_pymordial_controller_init():
 
 def test_add_app():
     """Test adding an app."""
-    with patch("pymordial.core.controller.PymordialAdbDevice"):
-        with patch("pymordial.core.controller.PymordialBluestacksDevice"):
-            with patch("pymordial.core.controller.PymordialUiDevice"):
-                controller = PymordialController()
+    with patch("pymordial.core.bluestacks_controller.PymordialAdbDevice"):
+        with patch("pymordial.core.bluestacks_controller.PymordialBluestacksDevice"):
+            with patch("pymordial.core.bluestacks_controller.PymordialUiDevice"):
+                controller = PymordialBluestacksController()
                 app = PymordialApp(app_name="TestApp", package_name="com.test")
                 controller.add_app(app)
                 assert "TestApp" in controller._apps

--- a/tests/core/test_pymordial_app.py
+++ b/tests/core/test_pymordial_app.py
@@ -73,11 +73,11 @@ def test_open_without_controller(mock_config):
 
 def test_open_with_controller(mock_config, mock_adb_controller):
     """Test opening app with controller."""
-    from pymordial.core.controller import PymordialController
+    from pymordial.core.bluestacks_controller import PymordialBluestacksController
 
     app = PymordialApp(app_name="TestApp", package_name="com.test.app")
 
-    controller = Mock(spec=PymordialController)
+    controller = Mock(spec=PymordialBluestacksController)
     controller.adb = mock_adb_controller
     app.pymordial_controller = controller
 
@@ -97,11 +97,11 @@ def test_close_without_controller(mock_config):
 
 def test_close_with_controller(mock_config, mock_adb_controller):
     """Test closing app with controller."""
-    from pymordial.core.controller import PymordialController
+    from pymordial.core.bluestacks_controller import PymordialBluestacksController
 
     app = PymordialApp(app_name="TestApp", package_name="com.test.app")
 
-    controller = Mock(spec=PymordialController)
+    controller = Mock(spec=PymordialBluestacksController)
     controller.adb = mock_adb_controller
     app.pymordial_controller = controller
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from pymordial.core.controller import PymordialController
+from pymordial.core.bluestacks_controller import PymordialBluestacksController
 from pymordial.devices.adb_device import PymordialAdbDevice
 
 
@@ -29,8 +29,8 @@ def real_bluestacks_controller(real_pymordial_controller):
 
 @pytest.fixture(scope="session")
 def real_pymordial_controller():
-    """Returns a real PymordialController."""
-    controller = PymordialController()
+    """Returns a real PymordialBluestacksController."""
+    controller = PymordialBluestacksController()
     try:
         controller.bluestacks.open()
     except Exception as e:

--- a/tests/integration/test_interaction.py
+++ b/tests/integration/test_interaction.py
@@ -5,11 +5,13 @@ import time
 import pytest
 
 from pymordial.core.app import PymordialApp
-from pymordial.core.controller import PymordialController
+from pymordial.core.bluestacks_controller import PymordialBluestacksController
 
 
 @pytest.mark.integration
-def test_find_and_click_element(real_pymordial_controller: PymordialController):
+def test_find_and_click_element(
+    real_pymordial_controller: PymordialBluestacksController,
+):
     """Verifies that an element can be found and clicked."""
     import os
 
@@ -46,7 +48,7 @@ def test_find_and_click_element(real_pymordial_controller: PymordialController):
 
 
 @pytest.mark.integration
-def test_ocr_text_extraction(real_pymordial_controller: PymordialController):
+def test_ocr_text_extraction(real_pymordial_controller: PymordialBluestacksController):
     """Verifies that text can be extracted from the screen."""
     time.sleep(5)
     # Ensure we are on home screen
@@ -74,7 +76,7 @@ def test_ocr_text_extraction(real_pymordial_controller: PymordialController):
 
 
 @pytest.mark.integration
-def test_app_lifecycle(real_pymordial_controller: PymordialController):
+def test_app_lifecycle(real_pymordial_controller: PymordialBluestacksController):
     """Verifies app open/close lifecycle using Settings app."""
     # Create a PymordialApp for Settings
     settings_app = PymordialApp(

--- a/tests/integration/test_streaming.py
+++ b/tests/integration/test_streaming.py
@@ -4,11 +4,13 @@ import time
 
 import pytest
 
-from pymordial.core.controller import PymordialController
+from pymordial.core.bluestacks_controller import PymordialBluestacksController
 
 
 @pytest.mark.integration
-def test_streaming_basic_functionality(real_pymordial_controller: PymordialController):
+def test_streaming_basic_functionality(
+    real_pymordial_controller: PymordialBluestacksController,
+):
     """Test basic streaming: start, get frames, stop."""
     # Start streaming
     try:
@@ -45,7 +47,9 @@ def test_streaming_basic_functionality(real_pymordial_controller: PymordialContr
 
 
 @pytest.mark.integration
-def test_streaming_performance(real_pymordial_controller: PymordialController):
+def test_streaming_performance(
+    real_pymordial_controller: PymordialBluestacksController,
+):
     """Test that streaming returns consistent frames rapidly.
 
     Note: This test verifies streaming functionality rather than making

--- a/tests/unit/test_convenience_methods.py
+++ b/tests/unit/test_convenience_methods.py
@@ -1,24 +1,24 @@
-"""Tests for PymordialController convenience methods."""
+"""Tests for PymordialBluestacksController convenience methods."""
 
 from unittest.mock import Mock, patch
 
 import pytest
 
-from pymordial.core.controller import PymordialController
+from pymordial.core.bluestacks_controller import PymordialBluestacksController
 
 
 class TestConvenienceMethods:
-    """Test convenience delegation methods in PymordialController."""
+    """Test convenience delegation methods in PymordialBluestacksController."""
 
     @pytest.fixture
     def controller(self):
-        """Create a PymordialController with mocked sub-controllers."""
+        """Create a PymordialBluestacksController with mocked sub-controllers."""
         with (
-            patch("pymordial.core.controller.PymordialAdbDevice"),
-            patch("pymordial.core.controller.PymordialUiDevice"),
-            patch("pymordial.core.controller.PymordialBluestacksDevice"),
+            patch("pymordial.core.bluestacks_controller.PymordialAdbDevice"),
+            patch("pymordial.core.bluestacks_controller.PymordialUiDevice"),
+            patch("pymordial.core.bluestacks_controller.PymordialBluestacksDevice"),
         ):
-            controller = PymordialController()
+            controller = PymordialBluestacksController()
             # Mock the sub-controllers
             controller.adb = Mock()
             controller.ui = Mock()


### PR DESCRIPTION
Refactors the core `PymordialController` to `PymordialBluestacksController` to specifically denote its role in orchestrating BlueStacks instances. This change clarifies the architecture and serves as a foundation for the "Extending Pymordial" guide, facilitating future multi-platform support (e.g., iOS, Windows).

**Changes:**
- Renamed `src/pymordial/core/controller.py` to `src/pymordial/core/bluestacks_controller.py`.
- Renamed class `PymordialController` to `PymordialBluestacksController`.
- Updated all internal references, type hints, and docstrings.
- Updated all example scripts (`examples/*.py`) to use the new class name.
- Updated tests to reflect the rename.
- Verified all tests pass.

**Documentation:**
- Updated `Wiki` draft to use `PymordialBluestacksController` in examples.
- Added comprehensive "Extending Pymordial" section to Wiki.