### PR TITLE
docs: Fix broken mkdocstrings references in devices.md

### DIFF
--- a/docs/reference/devices.md
+++ b/docs/reference/devices.md
@@ -1,3 +1,13 @@
 # Device Reference
 
-::: pymordial.core.blueprints.device.PymordialDevice
+## Bridge Device
+::: pymordial.core.blueprints.bridge_device.PymordialBridgeDevice
+
+## Vision Device
+::: pymordial.core.blueprints.vision_device.PymordialVisionDevice
+
+## Emulator Device
+::: pymordial.core.blueprints.emulator_device.PymordialEmulatorDevice
+
+## OCR Device
+::: pymordial.core.blueprints.ocr_device.PymordialOCRDevice

--- a/docs/reference/devices.md
+++ b/docs/reference/devices.md
@@ -1,5 +1,7 @@
 # Device Reference
 
+This document provides a reference for the abstract base classes (blueprints) that define the core functionalities for different types of devices in Pymordial. Each blueprint serves as a contract for concrete device implementations.
+
 ## Bridge Device
 ::: pymordial.core.blueprints.bridge_device.PymordialBridgeDevice
 


### PR DESCRIPTION
Fixes a critical issue where mkdocstrings was referencing a non-existent module.