### PR TITLE
fix(docs): Update mkdocs.yml site_url

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: Pymordial
 site_description: The universal python automation framework.
-site_url: https://github.com/IAmNo1Special/Pymordial
+site_url: https://iamno1special.github.io/Pymordial/
 repo_url: https://github.com/IAmNo1Special/Pymordial
 repo_name: IAmNo1Special/Pymordial
 


### PR DESCRIPTION
Fixes 404/broken links on GitHub Pages by setting the correct site_url to https://iamno1special.github.io/Pymordial/.