### PR TITLE
refactor(core): convert data models to dataclasses and update docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - **Platform Agnostic Core**:
-    - Converted `PymordialApp` to an Abstract Base Class (ABC).
+    - Converted `PymordialApp`, `PymordialScreen`, and `PymordialElement` to pure dataclasses.
     - Removed all Android-specific logical dependencies (package name, ADB commands) from core.
     - Cleaned `configs.yaml` of ADB/BlueStacks settings; now only contains generic `app`, `element`, `controller` config.
     - Updated `PymordialElement` to default to 1920x1080 resolution if not specified, removing dependency on BlueStacks config.
+    - Moved `element.py` from `core/blueprints/` to `ui/`.
+- **Blueprint Cleanup**:
+    - Removed `basicConfig` from device blueprints (`PymordialBridgeDevice`, `PymordialVisionDevice`, `PymordialEmulatorDevice`).
+    - Aligned `PymordialEmulatorDevice` state machine to be an instance attribute.
 - **Configuration**:
     - Updated `pymordial_config.example.yaml` to match the new minimal schema.
 - **Testing**:
-    - Added rigorous testing for abstract base classes.
+    - Added rigorous testing for dataclass validation and state machine logic.
     - Restored `ConcreteApp` fixtures to verify core lifecycle logic without platform dependencies.
 - **Build**:
     - Updated `uv-build` dependency constraints.

--- a/README.md
+++ b/README.md
@@ -64,22 +64,21 @@ class MyPlatformController(PymordialController):
     # ... implement other abstract methods ...
 ```
 
-### 2. Implement an App
+### 2. Define an App
+
+`PymordialApp` is a **pure data model**. It holds app metadata and screens:
 
 ```python
 from pymordial.core.app import PymordialApp
+from pymordial.core.screen import PymordialScreen
+from pymordial.ui.image import PymordialImage
 
-class MyApp(PymordialApp):
-    """A concrete app implementation."""
-    
-    def open(self) -> bool:
-        print(f"Launching {self.app_name}...")
-        # device_bridge.launch(self.package_id)
-        return True
+# Create an app with screens and elements
+main_menu = PymordialScreen(name="main_menu")
+main_menu.add_element(PymordialImage(label="play_button", source_path="assets/play.png"))
 
-    def close(self) -> bool:
-        print(f"Closing {self.app_name}...")
-        return True
+game = PymordialApp(app_name="SuperGame")
+game.add_screen(main_menu)
 ```
 
 ### 3. Automate!
@@ -89,17 +88,15 @@ Once implemented, you get the full power of Pymordial's state machine and elemen
 ```python
 # 1. Setup
 controller = MyPlatformController()
-game = MyApp("SuperGame", package_id="com.game")
-controller.add_app(game)
+controller.add_app(game)  # Register the app
 
-# 2. Define Elements
-from pymordial.ui.image import PymordialImage
-start_btn = PymordialImage("start", "assets/start.png")
+# 2. Operate via Controller (which delegates to BridgeDevice)
+controller.open_app("SuperGame", "com.game", timeout=60, wait_time=10)
 
-# 3. Operations
-game.open()
-if controller.is_element_visible(start_btn):
-    controller.click_element(start_btn)
+# 3. Find and Click Elements
+play_button = game.get_screen("main_menu").get_element("play_button")
+if controller.is_element_visible(play_button):
+    controller.click_element(play_button)
 ```
 
 ---

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,15 +6,17 @@ This release marks a major architectural shift, decoupling the core framework fr
 
 ### Highlights
 
-*   **Abstract Core**: `PymordialApp` is now an Abstract Base Class (ABC). It defines the contract for applications (`open`, `close`, `state`) but contains no platform logic.
+*   **Dataclass Architecture**: `PymordialApp`, `PymordialScreen`, and `PymordialElement` are now pure dataclasses with auto-generated IDs and built-in validation.
 *   **Android Decoupling**: Moved all Android package management, ADB commands, and BlueStacks logic out of the core library. These will live in platform-specific extensions (e.g., `pymordialblue`).
 *   **Clean Configuration**: The `configs.yaml` and `TypedDict` structures have been stripped of all ADB/BlueStacks settings. The core config now only manages generic `app`, `element`, and `controller` settings.
-*   **Enhanced Testing**: Added rigorous verification for abstract interfaces and state machine logic using concrete test implementations.
+*   **Blueprint Cleanup**: Removed improper `basicConfig` calls from device blueprints and aligned state machines to be instance attributes.
+*   **Enhanced Testing**: Added rigorous verification for dataclass validation and state machine logic using concrete test implementations.
 
 ### ⚠️ Breaking Changes
 
-*   **PymordialApp Instantiation**: You can no longer instantiate `PymordialApp` directly. You must use a concrete implementation (e.g., `PymordialAndroidApp` from a platform extension).
+*   **PymordialApp Changes**: `PymordialApp` is now a dataclass, not an ABC. You can instantiate it directly or extend it with additional fields.
 *   **Configuration Keys**: Removed `adb`, `bluestacks`, `image_controller`, `extract_strategy`, and `setup` sections from the configuration.
+*   **Element Location**: `PymordialElement` moved from `pymordial.core.blueprints.element` to `pymordial.ui.element`.
 
 ### 📦 Installation
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: Pymordial
 site_description: The universal python automation framework.
-site_url: https://github.com/IAmNo1Special/Pymordial
+site_url: https://iamno1special.github.io/Pymordial/
 repo_url: https://github.com/IAmNo1Special/Pymordial
 repo_name: IAmNo1Special/Pymordial
 

--- a/src/pymordial/__init__.py
+++ b/src/pymordial/__init__.py
@@ -5,11 +5,11 @@ automating BlueStacks interactions.
 """
 
 from pymordial.core.app import PymordialApp
-from pymordial.core.blueprints.element import PymordialElement
 from pymordial.core.blueprints.emulator_device import EmulatorState
 from pymordial.core.controller import PymordialController
 from pymordial.core.screen import PymordialScreen
 from pymordial.core.state_machine import AppState, StateMachine
+from pymordial.ui.element import PymordialElement
 from pymordial.ui.image import PymordialImage
 from pymordial.ui.pixel import PymordialPixel
 from pymordial.ui.text import PymordialText

--- a/src/pymordial/core/__init__.py
+++ b/src/pymordial/core/__init__.py
@@ -4,7 +4,6 @@ Core module for Pymordial.
 
 from pymordial.core.app import PymordialApp
 from pymordial.core.blueprints.bridge_device import PymordialBridgeDevice
-from pymordial.core.blueprints.element import PymordialElement
 from pymordial.core.blueprints.emulator_device import (
     EmulatorState,
     PymordialEmulatorDevice,
@@ -13,6 +12,7 @@ from pymordial.core.blueprints.vision_device import PymordialVisionDevice
 from pymordial.core.controller import PymordialController
 from pymordial.core.screen import PymordialScreen
 from pymordial.core.state_machine import AppState, StateMachine
+from pymordial.ui.element import PymordialElement
 from pymordial.ui.image import PymordialImage
 from pymordial.ui.pixel import PymordialPixel
 from pymordial.ui.text import PymordialText

--- a/src/pymordial/core/app.py
+++ b/src/pymordial/core/app.py
@@ -2,63 +2,64 @@
 
 from __future__ import annotations
 
-from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING
+from dataclasses import dataclass, field
+from uuid import uuid4
 
+from pymordial.core.screen import PymordialScreen
 from pymordial.core.state_machine import AppState, StateMachine
-
-if TYPE_CHECKING:
-    from pymordial.core.blueprints.element import PymordialElement
-    from pymordial.core.controller import PymordialController
-    from pymordial.core.screen import PymordialScreen
+from pymordial.ui.element import PymordialElement
+from pymordial.utils.exceptions import ScreenNotFoundError
 
 
-class PymordialApp(ABC):
-    """Abstract base class for application lifecycle management.
-
-    Concrete implementations should handle platform-specific app launching,
-    such as Android package management or iOS app bundles.
+@dataclass
+class PymordialApp:
+    """Represents an application.
 
     Attributes:
         app_name: The display name of the app.
-        pymordial_controller: The controller managing this app.
         screens: A dictionary of screens belonging to this app.
-        app_state: The state machine managing the app's lifecycle.
         ready_element: Optional element to detect when app is fully loaded.
+        app_state: The state machine managing the app's lifecycle (auto-generated).
+        app_id: Unique identifier for this app instance (auto-generated).
     """
 
-    def __init__(
-        self,
-        app_name: str,
-        screens: dict[str, "PymordialScreen"] | None = None,
-        ready_element: "PymordialElement | None" = None,
-    ) -> None:
-        """Initializes a PymordialApp.
-
-        Args:
-            app_name: The display name of the app.
-            screens: Optional dictionary of screens.
-            ready_element: Optional element that indicates app is ready.
-
-        Raises:
-            ValueError: If app_name is empty.
-        """
-        if not app_name:
-            raise ValueError("app_name must be a non-empty string")
-
-        self.app_name: str = app_name
-        self.pymordial_controller: "PymordialController | None" = None
-        self.screens: dict[str, "PymordialScreen"] = (
-            screens if screens is not None else {}
-        )
-        self.ready_element: "PymordialElement | None" = ready_element
-
-        self.app_state = StateMachine(
+    app_name: str
+    screens: dict[str, PymordialScreen] = field(default_factory=dict)
+    ready_element: PymordialElement | None = None
+    app_state: StateMachine = field(
+        default_factory=lambda: StateMachine(
             current_state=AppState.CLOSED,
             transitions=AppState.get_transitions(),
-        )
+        ),
+        init=False,
+    )
+    app_id: str = field(default_factory=lambda: str(uuid4()), init=False)
 
-    def add_screen(self, screen: "PymordialScreen") -> None:
+    def __post_init__(self) -> None:
+        """Initializes a PymordialApp.
+
+        Raises:
+            TypeError: If app_name is not a string.
+            ValueError: If app_name is empty.
+            TypeError: If screens is not a dictionary.
+            TypeError: If ready_element is not a PymordialElement or None.
+            TypeError: If app_state is not a StateMachine.
+        """
+        if not isinstance(self.app_name, str):
+            raise TypeError("app_name must be a string")
+        if not self.app_name:
+            raise ValueError("app_name must be a non-empty string")
+
+        if not isinstance(self.screens, dict):
+            raise TypeError("screens must be a dictionary")
+
+        if not isinstance(self.ready_element, PymordialElement | None):
+            raise TypeError("ready_element must be a PymordialElement or None")
+
+        if not isinstance(self.app_state, StateMachine):
+            raise TypeError("app_state must be a StateMachine")
+
+    def add_screen(self, screen: PymordialScreen) -> None:
         """Adds a screen to the app.
 
         Args:
@@ -66,52 +67,40 @@ class PymordialApp(ABC):
         """
         self.screens[screen.name] = screen
 
-    @abstractmethod
-    def open(self) -> bool:
-        """Opens the application.
+    def get_screen(self, name: str) -> PymordialScreen:
+        """Retrieves a screen by its name.
+
+        Args:
+            name: The name of the screen to retrieve.
 
         Returns:
-            True if the app was opened successfully, False otherwise.
-        """
-        pass
+            The PymordialScreen instance.
 
-    @abstractmethod
-    def close(self) -> bool:
-        """Closes the application.
+        Raises:
+            ScreenNotFoundError: If the screen is not found.
+        """
+        try:
+            return self.screens[name]
+        except KeyError:
+            raise ScreenNotFoundError(
+                f"Screen '{name}' not found within the '{self.app_name}' app."
+            )
+
+    def remove_screen(self, name: str) -> PymordialScreen:
+        """Removes a screen by its name.
+
+        Args:
+            name: The name of the screen to remove.
 
         Returns:
-            True if the app was closed successfully, False otherwise.
+            The removed PymordialScreen instance.
+
+        Raises:
+            ScreenNotFoundError: If the screen is not found.
         """
-        pass
-
-    def is_open(self) -> bool:
-        """Checks if the app is in the READY state.
-
-        Returns:
-            True if the app state is READY, False otherwise.
-        """
-        return self.app_state.current_state == AppState.READY
-
-    def is_loading(self) -> bool:
-        """Checks if the app is in the LOADING state.
-
-        Returns:
-            True if the app state is LOADING, False otherwise.
-        """
-        return self.app_state.current_state == AppState.LOADING
-
-    def is_closed(self) -> bool:
-        """Checks if the app is in the CLOSED state.
-
-        Returns:
-            True if the app state is CLOSED, False otherwise.
-        """
-        return self.app_state.current_state == AppState.CLOSED
-
-    def __repr__(self) -> str:
-        """Returns a string representation of the app."""
-        return (
-            f"{self.__class__.__name__}("
-            f"app_name='{self.app_name}', "
-            f"state={self.app_state.current_state.name})"
-        )
+        try:
+            return self.screens.pop(name)
+        except KeyError:
+            raise ScreenNotFoundError(
+                f"Screen '{name}' not found within the '{self.app_name}' app."
+            )

--- a/src/pymordial/core/app.py
+++ b/src/pymordial/core/app.py
@@ -11,7 +11,7 @@ from pymordial.ui.element import PymordialElement
 from pymordial.utils.exceptions import ScreenNotFoundError
 
 
-@dataclass
+@dataclass(eq=False)
 class PymordialApp:
     """Represents an application.
 
@@ -104,3 +104,13 @@ class PymordialApp:
             raise ScreenNotFoundError(
                 f"Screen '{name}' not found within the '{self.app_name}' app."
             )
+
+    def __hash__(self) -> int:
+        """Returns hash based on unique app_id."""
+        return hash(self.app_id)
+
+    def __eq__(self, other) -> bool:
+        """Compares apps by their unique app_id."""
+        if not isinstance(other, PymordialApp):
+            return NotImplemented
+        return self.app_id == other.app_id

--- a/src/pymordial/core/blueprints/__init__.py
+++ b/src/pymordial/core/blueprints/__init__.py
@@ -1,0 +1,1 @@
+# Core blueprints package

--- a/src/pymordial/core/blueprints/bridge_device.py
+++ b/src/pymordial/core/blueprints/bridge_device.py
@@ -1,5 +1,7 @@
+import logging
 from abc import ABC, abstractmethod
-from logging import DEBUG, basicConfig, getLogger
+
+logger = logging.getLogger(__name__)
 
 
 class PymordialBridgeDevice(ABC):
@@ -7,11 +9,6 @@ class PymordialBridgeDevice(ABC):
 
     Defines the low-level commands to control the device hardware or emulator.
     """
-
-    logger = getLogger("PymordialBridgeDevice")
-    basicConfig(
-        level=DEBUG, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
-    )
 
     @abstractmethod
     def connect(self):

--- a/src/pymordial/core/blueprints/emulator_device.py
+++ b/src/pymordial/core/blueprints/emulator_device.py
@@ -1,8 +1,10 @@
+import logging
 from abc import ABC, abstractmethod
 from enum import Enum, auto
-from logging import DEBUG, basicConfig, getLogger
 
 from pymordial.core.state_machine import StateMachine
+
+logger = logging.getLogger(__name__)
 
 
 class EmulatorState(Enum):
@@ -30,18 +32,14 @@ class PymordialEmulatorDevice(ABC):
     """Abstract interface for controlling emulator software (e.g., BlueStacks).
 
     Attributes:
-        logger: Logger instance for emulator operations.
         state: StateMachine tracking the emulator's lifecycle.
     """
 
-    logger = getLogger("PymordialEmulatorDevice")
-    state = StateMachine(
-        current_state=EmulatorState.CLOSED,
-        transitions=EmulatorState.get_transitions(),
-    )
-    basicConfig(
-        level=DEBUG, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
-    )
+    def __init__(self):
+        self.state = StateMachine(
+            current_state=EmulatorState.CLOSED,
+            transitions=EmulatorState.get_transitions(),
+        )
 
     @abstractmethod
     def open(self):

--- a/src/pymordial/core/blueprints/vision_device.py
+++ b/src/pymordial/core/blueprints/vision_device.py
@@ -1,9 +1,11 @@
+import logging
 from abc import ABC, abstractmethod
-from logging import DEBUG, basicConfig, getLogger
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from PIL import Image
+
+logger = logging.getLogger(__name__)
 
 
 class PymordialVisionDevice(ABC):
@@ -12,11 +14,6 @@ class PymordialVisionDevice(ABC):
     Defines the contract for visual operations such as screen scaling,
     pixel color checking, and text extraction/finding.
     """
-
-    logger = getLogger("PymordialVisionDevice")
-    basicConfig(
-        level=DEBUG, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
-    )
 
     @abstractmethod
     def scale_img_to_screen(self) -> "Image.Image":

--- a/src/pymordial/core/controller.py
+++ b/src/pymordial/core/controller.py
@@ -89,9 +89,6 @@ class PymordialController(ABC):
 
         Args:
             app: The PymordialApp instance to register.
-
-        Raises:
-            ValueError: If the app name is invalid or conflicts (though current logic only overwrites, we can keep it simple or add check if needed, but existing logic overwrote).
         """
         # Sanitize app_name for attribute access
         sanitized_name = app.app_name.replace("-", "_").replace(" ", "_")

--- a/src/pymordial/core/controller.py
+++ b/src/pymordial/core/controller.py
@@ -86,6 +86,7 @@ class PymordialController(ABC):
         """Registers a PymordialApp instance with this controller.
 
         This method adds the app to the internal registry using a sanitized name.
+        If an app with the same sanitized name already exists, it will be overwritten.
 
         Args:
             app: The PymordialApp instance to register.

--- a/src/pymordial/core/controller.py
+++ b/src/pymordial/core/controller.py
@@ -8,9 +8,9 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from pymordial.core.app import PymordialApp
-    from pymordial.core.blueprints.element import PymordialElement
     from pymordial.core.blueprints.extract_strategy import PymordialExtractStrategy
     from pymordial.core.plugin import PymordialPlugin
+    from pymordial.ui.element import PymordialElement
 
 logger = logging.getLogger(__name__)
 
@@ -85,27 +85,14 @@ class PymordialController(ABC):
     def add_app(self, app: "PymordialApp") -> None:
         """Registers a PymordialApp instance with this controller.
 
-        This method:
-        1. Checks if the app is already registered elsewhere.
-        2. Sets the app's `pymordial_controller` reference to `self`.
-        3. Adds the app to the internal registry using a sanitized name.
+        This method adds the app to the internal registry using a sanitized name.
 
         Args:
             app: The PymordialApp instance to register.
 
         Raises:
-            ValueError: If the app is already registered with a different controller.
+            ValueError: If the app name is invalid or conflicts (though current logic only overwrites, we can keep it simple or add check if needed, but existing logic overwrote).
         """
-        # Set controller reference if not set
-        if (
-            app.pymordial_controller is not None
-            and app.pymordial_controller is not self
-        ):
-            raise ValueError(
-                f"App '{app.app_name}' is already registered with a different controller."
-            )
-        app.pymordial_controller = self
-
         # Sanitize app_name for attribute access
         sanitized_name = app.app_name.replace("-", "_").replace(" ", "_")
 

--- a/src/pymordial/core/screen.py
+++ b/src/pymordial/core/screen.py
@@ -1,8 +1,9 @@
 """Container for Pymordial UI elements representing a screen."""
 
 from dataclasses import dataclass, field
+from uuid import uuid4
 
-from pymordial.core.blueprints.element import PymordialElement
+from pymordial.ui.element import PymordialElement
 from pymordial.utils.exceptions import ElementNotFoundError
 
 
@@ -13,10 +14,12 @@ class PymordialScreen:
     Attributes:
         name: The name of the screen.
         elements: A dictionary of elements belonging to this screen.
+        screen_id: Unique identifier for this screen instance (auto-generated).
     """
 
     name: str
     elements: dict[str, PymordialElement] = field(default_factory=dict)
+    screen_id: str = field(default_factory=lambda: str(uuid4()), init=False)
 
     def __post_init__(self) -> None:
         """Validates the screen attributes after initialization.
@@ -96,11 +99,3 @@ class PymordialScreen:
             raise ElementNotFoundError(
                 f"Element '{label}' not found on screen '{self.name}'"
             )
-
-    def __repr__(self) -> str:
-        """Returns a string representation of the screen."""
-        return (
-            f"PymordialScreen("
-            f"name='{self.name}', "
-            f"elements={str(self.elements)})"
-        )

--- a/src/pymordial/ui/element.py
+++ b/src/pymordial/ui/element.py
@@ -5,7 +5,7 @@ from typing import final
 from uuid import uuid4
 
 
-@dataclass(kw_only=True)
+@dataclass(kw_only=True, eq=False)
 class PymordialElement:
     """Abstract base class for all UI elements.
 
@@ -121,3 +121,13 @@ class PymordialElement:
                 int(self.position[1] + self.size[1] // 2),
             )
         return self.position
+
+    def __hash__(self) -> int:
+        """Returns hash based on unique element_id."""
+        return hash(self.element_id)
+
+    def __eq__(self, other) -> bool:
+        """Compares elements by their unique element_id."""
+        if not isinstance(other, PymordialElement):
+            return NotImplemented
+        return self.element_id == other.element_id

--- a/src/pymordial/ui/element.py
+++ b/src/pymordial/ui/element.py
@@ -1,33 +1,28 @@
 """Abstract base class for Pymordial UI elements."""
 
-from abc import ABC
 from dataclasses import dataclass, field
 from typing import final
 from uuid import uuid4
 
-from pymordial.utils.config import get_config
 
-_CONFIG = get_config()
-
-
-@dataclass(kw_only=True, eq=False)
-class PymordialElement(ABC):
+@dataclass(kw_only=True)
+class PymordialElement:
     """Abstract base class for all UI elements.
 
     Attributes:
-        id: Unique identifier for this element instance (auto-generated).
         label: A unique identifier for the element.
         position: Optional (x, y) coordinates of the element's bounding box.
         size: Optional (width, height) of the element's bounding box.
         og_resolution: The original window resolution (width, height) used when
             defining the element.
+        element_id: Unique identifier for this element instance (auto-generated).
     """
 
-    id: str = field(default_factory=lambda: str(uuid4()), init=False, repr=False)
     label: str
     position: tuple[int | float, int | float] | None = None
     size: tuple[int | float, int | float] | None = None
     og_resolution: tuple[int, int] | None = None
+    element_id: str = field(default_factory=lambda: str(uuid4()), init=False)
 
     def __post_init__(self):
         """Post-initialization processing and validation.
@@ -126,22 +121,3 @@ class PymordialElement(ABC):
                 int(self.position[1] + self.size[1] // 2),
             )
         return self.position
-
-    def __hash__(self) -> int:
-        """Returns hash based on unique ID."""
-        return hash(self.id)
-
-    def __eq__(self, other) -> bool:
-        """Compares elements by their unique ID."""
-        if not isinstance(other, PymordialElement):
-            return False
-        return self.id == other.id
-
-    def __repr__(self) -> str:
-        """Returns a string representation of the element."""
-        return (
-            f"{self.__class__.__name__}("
-            f"label='{self.label}', "
-            f"position={self.position}, "
-            f"size={self.size})"
-        )

--- a/src/pymordial/ui/image.py
+++ b/src/pymordial/ui/image.py
@@ -3,10 +3,7 @@
 from dataclasses import dataclass
 from pathlib import Path
 
-from pymordial.core.blueprints.element import PymordialElement
-from pymordial.utils.config import get_config
-
-_CONFIG = get_config()
+from pymordial.ui.element import PymordialElement
 
 
 @dataclass(kw_only=True)
@@ -59,14 +56,3 @@ class PymordialImage(PymordialElement):
                     f"Image text must be a string, not {type(self.image_text).__name__}"
                 )
             self.image_text = self.image_text.lower()
-
-    def __repr__(self) -> str:
-        """Returns a string representation of the image element."""
-        return (
-            f"PymordialImage("
-            f"label='{self.label}', "
-            f"filepath='{self.filepath}', "
-            f"confidence={self.confidence}, "
-            f"position={self.position}, "
-            f"size={self.size})"
-        )

--- a/src/pymordial/ui/pixel.py
+++ b/src/pymordial/ui/pixel.py
@@ -1,11 +1,8 @@
 """Implementation of PymordialPixel element."""
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 
-from pymordial.core.blueprints.element import PymordialElement
-from pymordial.utils.config import get_config
-
-_CONFIG = get_config()
+from pymordial.ui.element import PymordialElement
 
 
 @dataclass(kw_only=True)
@@ -15,16 +12,10 @@ class PymordialPixel(PymordialElement):
     Attributes:
         pixel_color: The expected RGB color tuple (r, g, b).
         tolerance: Color matching tolerance (0-255).
-
-    Note:
-        The size attribute is automatically set to the pixel_size from config
-        and should not be specified by users.
     """
 
     pixel_color: tuple[int, int, int]
     tolerance: int = 0
-    # Override parent's size to always be PIXEL_SIZE from config
-    size: tuple[int | float, int | float] = field(init=False)
 
     def __post_init__(self):
         """Post-initialization processing and validation.
@@ -33,11 +24,9 @@ class PymordialPixel(PymordialElement):
             TypeError: If pixel_color is not a tuple of integers, or tolerance is not an integer.
             ValueError: If pixel_color is not (r,g,b), contains values outside 0-255, or if tolerance is invalid.
         """
-        # Override parent's size to always be PIXEL_SIZE from config
-        self.size = tuple(_CONFIG["element"]["pixel_size"])
+        self.size = (1, 1)
         super().__post_init__()
 
-        # Validate pixel_color
         if not isinstance(self.pixel_color, tuple):
             raise TypeError(
                 f"Pixel color must be a tuple, not {type(self.pixel_color).__name__}"
@@ -56,7 +45,6 @@ class PymordialPixel(PymordialElement):
                 f"All pixel color values must be between 0 and 255, got {self.pixel_color}"
             )
 
-        # Validate tolerance
         if not isinstance(self.tolerance, int):
             raise TypeError(
                 f"Tolerance must be an integer, not {type(self.tolerance).__name__}"
@@ -66,13 +54,3 @@ class PymordialPixel(PymordialElement):
             raise ValueError(
                 f"Tolerance must be between 0 and 255, got {self.tolerance}"
             )
-
-    def __repr__(self) -> str:
-        """Returns a string representation of the pixel element."""
-        return (
-            f"PymordialPixel("
-            f"label='{self.label}', "
-            f"position={self.position}, "
-            f"pixel_color={self.pixel_color}, "
-            f"tolerance={self.tolerance})"
-        )

--- a/src/pymordial/ui/text.py
+++ b/src/pymordial/ui/text.py
@@ -3,8 +3,8 @@
 from dataclasses import dataclass
 from pathlib import Path
 
-from pymordial.core.blueprints.element import PymordialElement
 from pymordial.core.blueprints.extract_strategy import PymordialExtractStrategy
+from pymordial.ui.element import PymordialElement
 
 
 @dataclass(kw_only=True)
@@ -51,13 +51,3 @@ class PymordialText(PymordialElement):
                 raise TypeError(
                     f"Extract strategy must be a PymordialExtractStrategy, not {type(self.extract_strategy).__name__}"
                 )
-
-    def __repr__(self) -> str:
-        """Returns a string representation of the text element."""
-        return (
-            f"PymordialText("
-            f"label='{self.label}', "
-            f"element_text='{self.element_text}', "
-            f"position={self.position}, "
-            f"size={self.size})"
-        )

--- a/src/pymordial/utils/exceptions.py
+++ b/src/pymordial/utils/exceptions.py
@@ -65,3 +65,12 @@ class ElementNotFoundError(PymordialError):
     - Attempting to retrieve a non-existent element from a screen
     - Attempting to remove a non-existent element from a screen
     """
+
+
+class ScreenNotFoundError(PymordialError):
+    """Error raised when a screen is not found.
+
+    This exception is raised when:
+    - Attempting to retrieve a non-existent screen from an app
+    - Attempting to remove a non-existent screen from an app
+    """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+from dataclasses import dataclass
+
 import pytest
 
 from pymordial.core.app import PymordialApp
@@ -42,25 +44,15 @@ class ConcreteController(PymordialController):
         return True
 
 
+@dataclass
 class ConcreteApp(PymordialApp):
     """Concrete implementation of PymordialApp for testing."""
 
-    def __init__(self, app_name: str, package_name: str):
-        super().__init__(app_name)
-        self.package_name = package_name
+    package_name: str = "com.test.app"
 
-    def _check_controller(self) -> None:
-        """Ensure implementation has a controller before operations."""
-        if not self.pymordial_controller:
-            raise ValueError(
-                f"{self.app_name}'s pymordial_controller is not initialized"
-            )
-
-    def open(self) -> bool:
-        self._check_controller()
-        # In a real impl, this would call controller specific methods
-        # Here we mock delegation to 'open_app' on the controller
-        result = self.pymordial_controller.open_app(
+    def open(self, controller: PymordialController) -> bool:
+        """Opens the app using the provided controller."""
+        result = controller.open_app(
             self.app_name,
             package_name=self.package_name,
             timeout=60,
@@ -70,9 +62,9 @@ class ConcreteApp(PymordialApp):
             self.app_state.transition_to(AppState.LOADING)
         return result
 
-    def close(self) -> bool:
-        self._check_controller()
-        result = self.pymordial_controller.close_app(
+    def close(self, controller: PymordialController) -> bool:
+        """Closes the app using the provided controller."""
+        result = controller.close_app(
             package_name=self.package_name,
             timeout=60,
             wait_time=1,
@@ -89,4 +81,4 @@ def mock_controller():
 
 @pytest.fixture
 def app():
-    return ConcreteApp("TestApp", "com.test.app")
+    return ConcreteApp(app_name="TestApp", package_name="com.test.app")

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -36,19 +36,26 @@ class TestPymordialControllerABC:
         assert expected.issubset(abstract_methods)
 
 
-class TestPymordialAppABC:
-    """Test PymordialApp abstract base class."""
+class TestPymordialApp:
+    """Test PymordialApp functionality."""
 
-    def test_cannot_instantiate_directly(self):
-        """ABC should not be instantiable."""
-        with pytest.raises(TypeError, match="abstract"):
-            PymordialApp("TestApp")
+    def test_instantiation(self):
+        """PymordialApp should be instantiable as a dataclass."""
+        app = PymordialApp(app_name="TestApp")
+        assert app.app_name == "TestApp"
+        assert app.screens == {}
+        assert app.app_id is not None
+        assert app.app_state.current_state == AppState.CLOSED
 
-    def test_has_required_abstract_methods(self):
-        """Verify expected abstract methods exist."""
-        abstract_methods = PymordialApp.__abstractmethods__
-        assert "open" in abstract_methods
-        assert "close" in abstract_methods
+    def test_validation_empty_name(self):
+        """app_name cannot be empty."""
+        with pytest.raises(ValueError, match="app_name must be a non-empty string"):
+            PymordialApp(app_name="")
+
+    def test_validation_invalid_type(self):
+        """app_name must be a string."""
+        with pytest.raises(TypeError, match="app_name must be a string"):
+            PymordialApp(app_name=123)  # type: ignore
 
 
 class TestPymordialAppImplementation:
@@ -58,12 +65,11 @@ class TestPymordialAppImplementation:
         """Test full app lifecycle delegates to controller correctly."""
         # 1. Registration
         mock_controller.add_app(app)
-        assert app.pymordial_controller is mock_controller
         assert "TestApp" in mock_controller.list_apps()
 
         # 2. Open App delegation
         mock_controller.open_app = MagicMock(return_value=True)
-        assert app.open() is True
+        assert app.open(mock_controller) is True
 
         mock_controller.open_app.assert_called_once()
         args, kwargs = mock_controller.open_app.call_args
@@ -76,19 +82,11 @@ class TestPymordialAppImplementation:
         app.app_state.transition_to(AppState.READY)
         mock_controller.close_app = MagicMock(return_value=True)
 
-        assert app.close() is True
+        assert app.close(mock_controller) is True
 
         mock_controller.close_app.assert_called_once()
         assert mock_controller.close_app.call_args[1]["package_name"] == "com.test.app"
         assert app.app_state.current_state == AppState.CLOSED
-
-    def test_app_requires_controller(self, app):
-        """App methods raise ValueError if controller is missing."""
-        with pytest.raises(ValueError, match="controller is not initialized"):
-            app.open()
-
-        with pytest.raises(ValueError, match="controller is not initialized"):
-            app.close()
 
 
 class TestStateMachine:


### PR DESCRIPTION
## Summary

This PR refactors the core data models to pure dataclasses and updates documentation to reflect the new architecture.

## Changes

### Data Models
- Converted `PymordialApp`, `PymordialScreen`, and `PymordialElement` to pure `@dataclass`es
- Removed ABC inheritance from data models
- Added auto-generated UUID fields (`app_id`, `screen_id`, `element_id`)
- Moved `element.py` from `core/blueprints/` to `ui/`

### Blueprint Cleanup
- Removed `basicConfig` from device blueprints (`PymordialBridgeDevice`, `PymordialVisionDevice`, `PymordialEmulatorDevice`)
- Aligned `PymordialEmulatorDevice` state machine to be an instance attribute

### Controller Updates
- Removed legacy `pymordial_controller` assignment in `add_app`
- Updated imports to new `ui.element` location

### Documentation
- Updated `CHANGELOG.md` to reflect dataclass architecture
- Updated `RELEASE_NOTES.md` with correct information
- Updated `README.md` with accurate examples showing data model usage
- Fixed `site_url` in `mkdocs.yml`

## Verification
- ✅ `uv run pytest` — All tests pass
- ✅ `uv run mkdocs build` — Documentation builds successfully
- ✅ Code formatted with `isort` and `black`